### PR TITLE
Fix license in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "flarum"
     ],
     "type": "flarum-extension",
-    "license": "mit",
+    "license": "MIT",
     "require": {
         "flarum/core": "^0.1.0-beta.15"
     },


### PR DESCRIPTION
Some tools does not recognize lowercased `mit` as MIT License. For example https://shields.io uses "unknown" color in such case:

![ce7367ba](https://user-images.githubusercontent.com/5972388/125204649-8defed00-e27e-11eb-9a60-5f5420493653.png)
